### PR TITLE
docs: Add correct versions of pytorch on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd AtlasNet
 #Dependencies
 conda create -n atlasnet python=3.6 --yes
 conda activate atlasnet
-conda install  pytorch torchvision cudatoolkit=10.1 -c pytorch --yes
+conda install pytorch==1.7.1 torchvision==0.8.2 cudatoolkit=10.1 -c pytorch --yes
 pip install --user --requirement  requirements.txt # pip dependencies
 ```
 


### PR DESCRIPTION
The version of pytorch that works properly with cuda 10.1 is not the latest one. The README as was installed the latest version of pytorch. Therefore, the correct versions of the pytorch package were added to the command. For reference, see https://pytorch.org/get-started/previous-versions/ and search for CUDA 10.1.